### PR TITLE
ci: build arm and amd image when push main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - "main"
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Dependencies
+        run: |
+          sudo apt update && sudo  apt install  -y nodejs npm
+      - # Add support for more platforms with QEMU (optional)
+        # https://github.com/docker/setup-qemu-action
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: network=host
+
+      - name: Login to  gitbub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_PAT }}
+      - name: build and publish image
+        env:
+          # fork friendly ^^
+          DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/fast-gpt
+        run: |
+          docker buildx build \
+          --platform linux/amd64,linux/arm64 \
+          --label "org.opencontainers.image.licenses=MIT" \
+          --push \
+          -t ${DOCKER_REPO}:latest \
+          -f Dockerfile \
+          .


### PR DESCRIPTION
fix #16 
Describe: Using ci to auto build arm64 and amd64 image when push in main branch.

First you should set secret.GH_PAT in ci secrets,the GH_PAT get from github,
here is the tutorial，https://blog.csdn.net/u014175572/article/details/55510825

I have test in my repo,https://github.com/xiao-jay/FastGPT/actions/runs/4772746401,after ci running,will get a fast-gpt package.
<img width="1376" alt="image" src="https://user-images.githubusercontent.com/87080562/233823490-d35e6d9c-ad50-4afe-9d9d-6594144bc63f.png">

