### PR TITLE
ci: let image build by ci auto link to fastgpt repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
         run: |
           docker buildx build \
           --platform linux/amd64,linux/arm64 \
+          --label "org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/FastGPT" \
+          --label "org.opencontainers.image.description=fast-gpt image" \
           --label "org.opencontainers.image.licenses=MIT" \
           --push \
           -t ${DOCKER_REPO}:latest \


### PR DESCRIPTION
now image will not auto link FastGPT repo,add `org.opencontainers.image.source` label in image will auto link FastGPT repo