### PR TITLE
fix: filter system prompt 字符串判空

### DIFF
--- a/src/service/plugins/searchKb.ts
+++ b/src/service/plugins/searchKb.ts
@@ -126,7 +126,7 @@ export const searchKb = async ({
         length: Math.floor(maxTokens * rate)
       })
     )
-    .join('\n');
+    .join('\n').trim();
 
   /* 高相似度+不回复 */
   if (!filterSystemPrompt && model.chat.searchMode === ModelVectorSearchModeEnum.hightSimilarity) {


### PR DESCRIPTION
修复 filterSystemPrompt为'\n'时, 判断有问题